### PR TITLE
Config for AIThinker ESP32-G Gateway

### DIFF
--- a/ESP32-G.yaml
+++ b/ESP32-G.yaml
@@ -1,0 +1,43 @@
+substitutions:
+  name: esp32g-proxy
+
+esphome:
+  name: ${name}
+  name_add_mac_suffix: true
+  project:
+    name: esphome.bluetooth-proxy
+    version: "1.0"
+
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+
+ethernet:
+  type: LAN8720
+  mdc_pin: GPIO23
+  mdio_pin: GPIO18
+  clk_mode: GPIO17_OUT
+  phy_addr: 1
+  power_pin: GPIO5
+
+api:
+logger:
+ota:
+
+dashboard_import:
+  package_import_url: github://esphome/bluetooth-proxies/esp32g.yaml@main
+
+esp32_ble_tracker:
+  scan_parameters:
+    interval: 1100ms
+    window: 1100ms
+    active: true
+
+bluetooth_proxy:
+  active: true
+
+button:
+- platform: safe_mode
+  name: Safe Mode Boot
+  entity_category: diagnostic


### PR DESCRIPTION
Inexpensive board comes with u.fl antenna connection, on board Ethernet, USB serial, 4 LEDs, 5v and 12v power input, reset and boot buttons and a proper case.
### https://docs.ai-thinker.com/en/blue_tooth_gateway 
### https://eadalabs.com/esp32g-smart-ethernet-gateway
